### PR TITLE
Update dependencies to modern versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,7 @@
-(defproject clojure-sample "1.0.1"
+(defproject clojure-sample "1.0.2"
   :description "Hello World Clojure Web App"
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [compojure "1.1.1"]
-                 [ring/ring-jetty-adapter "1.1.2"]]
+  :min-lein-version "2.0.0"
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [compojure "1.1.6"]
+                 [ring/ring-jetty-adapter "1.2.2"]]
   :main ^:skip-aot sample.app)


### PR DESCRIPTION
The existing versions of dependencies were so old that many of their
transitive dependencies were no longer available in Clojars, leading to
a bunch of error messages when deploying the sample app to Heroku.
